### PR TITLE
Fixed anonymous checkout bug

### DIFF
--- a/src/Merchello.Plugin.Payments.SagePay/Controllers/SagePayApiController.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/Controllers/SagePayApiController.cs
@@ -111,7 +111,7 @@ namespace Merchello.Plugin.Payments.SagePay.Controllers
             var invoice = _merchelloContext.Services.InvoiceService.GetByKey(invoiceKey);
             var payment = _merchelloContext.Services.PaymentService.GetByKey(paymentKey);
 
-            if (invoice == null || payment == null || invoice.CustomerKey == null)
+            if (invoice == null || payment == null)
             {
                 var ex = new NullReferenceException( string.Format( "Invalid argument exception. Arguments: invoiceKey={0}, paymentKey={1}", invoiceKey, paymentKey));
                 LogHelper.Error<SagePayApiController>("Payment not authorized.", ex);


### PR DESCRIPTION
To replicate the bug. Proceed to checkout as an anonymous customer, use
SagePay direct, and enter card details on the SagePay pages.

The redirection to receipt will fail and show a null reference error
message.

This is for the check against invoice.CustomerKey, which isn't required
to successfully mark the order as paid (and isn't used in the code that
follows).

Running Merchello 1.13.2 on Umbraco 7.3.4.
