### PR TITLE
Added the ability to do repeat payments

### DIFF
--- a/src/Merchello.Plugin.Payments.SagePay/Constants.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/Constants.cs
@@ -45,6 +45,13 @@ namespace Merchello.Plugin.Payments.SagePay
             // Stores the 3DSecure url
             public static string ThreeDSecureUrl = "ThreeDSecureUrl";
 
+            // Stores the vendor transaction reference code
+            public static string SagepayVendorTxCode = "SagepayVendorTxCode";
+
+            /// Stores the authorisation code
+            public static string SagepayTxAuthNo = "SagepayTxAuthNo";
+
+
         }
 
 

--- a/src/Merchello.Plugin.Payments.SagePay/Models/RepeatDetails.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/Models/RepeatDetails.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Merchello.Plugin.Payments.SagePay.Models
+{
+    public class RepeatDetails
+    {
+        /// <summary>
+        /// The security key from the transaction to repeat  
+        /// </summary>
+        public string RelatedSecurityKey { get; set; }
+
+        /// <summary>
+        /// The id from the original transaction
+        /// </summary>
+        public string RelatedVpsTxId { get; set; }
+
+        /// <summary>
+        /// The original vendor transaction code
+        /// </summary>
+        public string RelatedVendorTxCode { get; set; }
+
+        /// <summary>
+        /// The original auth code
+        /// </summary>
+        public string RelatedTxAuthNo { get; set; }
+
+        /// <summary>
+        /// The customer's CV2 code (optional)
+        /// </summary>
+        public string CV2 { get; set; }
+   
+
+    }
+}

--- a/src/Merchello.Plugin.Payments.SagePay/Models/RepeatDetailsExtensions.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/Models/RepeatDetailsExtensions.cs
@@ -1,0 +1,42 @@
+﻿using Merchello.Core.Gateways.Payment;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Merchello.Plugin.Payments.SagePay.Models
+{
+    public static class RepeatDetailsExtensions
+    {
+        public static ProcessorArgumentCollection AsProcessorArgumentCollection(this RepeatDetails repeatDetails)
+        {
+            return new ProcessorArgumentCollection()
+            {
+                { "relatedSecurityKey", repeatDetails.RelatedSecurityKey },
+                { "relatedVpsTxId", repeatDetails.RelatedVpsTxId },
+                { "relatedVendorTxCode", repeatDetails.RelatedVendorTxCode },
+                { "relatedTxAuthNo", repeatDetails.RelatedTxAuthNo },
+                { "cv2", repeatDetails.CV2 ?? "" }
+            };
+        }
+
+        public static RepeatDetails AsRepeatDetails(this ProcessorArgumentCollection args)
+        {
+            return new RepeatDetails()
+            {
+                RelatedSecurityKey = args.ArgValue("relatedSecurityKey"),
+                RelatedVpsTxId = args.ArgValue("relatedVpsTxId"),
+                RelatedVendorTxCode = args.ArgValue("relatedVendorTxCode"),
+                RelatedTxAuthNo = args.ArgValue("relatedTxAuthNo"),
+                CV2 = args.ArgValue("cv2")
+            };
+        }
+
+
+        private static string ArgValue(this ProcessorArgumentCollection args, string key)
+        {
+            return args.ContainsKey(key) ? args[key] : string.Empty;
+        }
+    }
+}

--- a/src/Merchello.Plugin.Payments.SagePay/SagePayDirectPaymentProcessor.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/SagePayDirectPaymentProcessor.cs
@@ -65,6 +65,15 @@ namespace Merchello.Plugin.Payments.SagePay
                                 {
                                     values.Add("TxType", "PAYMENT");
                                 }
+                                else if (property.Name == "Amount")
+                                {
+                                    // If amount has no decimal place, the property.getvalue method adds lots of zeros
+                                    var amount = property.GetValue(request).ToString();
+                                    var amountDec = decimal.Parse(amount);
+
+                                    values.Add(property.Name, amountDec.ToString("n2"));
+
+                                }
                                 else
                                 {
                                     values.Add(property.Name, property.GetValue(request).ToString());

--- a/src/Merchello.Plugin.Payments.SagePay/SagePayService/SagePayDirectIntegration.cs
+++ b/src/Merchello.Plugin.Payments.SagePay/SagePayService/SagePayDirectIntegration.cs
@@ -17,9 +17,9 @@ namespace Merchello.Plugin.Payments.SagePay.SagePayService
             _settings = settings;
         }
 
-        public IDirectPayment DirectPaymentRequest()
+        public IRepeatRequest RepeatRequest()
         {
-            IDirectPayment request = new DataObject();
+            IRepeatRequest request = new DataObject();
             return request;
         }
 
@@ -44,6 +44,24 @@ namespace Merchello.Plugin.Payments.SagePay.SagePayService
             return request;
         }
 
-        
+
+        public ICaptureResult DoRepeat(IRepeatRequest request, bool deferred)
+        {
+            if (deferred)
+                request.TransactionType = TransactionType.REPEATDEFERRED;
+            else
+                request.TransactionType = TransactionType.REPEAT;
+
+            if (request.Cv2 == null)
+            {
+                request.Cv2 = "";
+            }
+
+            RequestQueryString = BuildQueryString(request, ProtocolMessage.REPEAT_REQUEST, _settings.ProtocolVersion);
+            ResponseQueryString = ProcessWebRequestToSagePay(string.Format("https://{0}.sagepay.com/gateway/service/repeat.vsp", _settings.Environment), RequestQueryString);
+            ICaptureResult result = ConvertToCaptureResult(ResponseQueryString);
+            return result;
+        }
+
     }
 }


### PR DESCRIPTION
I have added the ability to use the SagePay repeat functionality for direct payments. This requires sending through repeat details from a previous transaction. To accomplish this I am now passing back the sagepay transaction details once a payment is processed so they can be saved on the client website for the next repeat transaction
